### PR TITLE
Fix slow docs and parity latest

### DIFF
--- a/traiders/backend/api/views/parity.py
+++ b/traiders/backend/api/views/parity.py
@@ -24,7 +24,7 @@ class ParityLatestViewSet(ReadOnlyModelViewSet):
     def get_queryset(self):
         parities = []
 
-        distinct_id_pairs = Parity.objects.values_list('base_equipment', 'target_equipment').distinct()
+        distinct_id_pairs = Parity.objects.order_by().values_list('base_equipment', 'target_equipment').distinct()
 
         for base, target in distinct_id_pairs:
             parity = Parity.objects.order_by('-date').filter(base_equipment_id=base,


### PR DESCRIPTION


```python
Parity.objects.values_list('base_equipment', 'target_equipment').distinct()
```
Because we have defined default ordering (-date) for the Parity model, Django generate SQL for distinct (base, target, date) triplets, which are too many (~6000). We need to disable the default ordering to get distinct (base, target) pairs:
```python
Parity.objects.order_by().values_list('base_equipment', 'target_equipment').distinct()
```

## Type of change
- [ ] Bug fix


## Checklist:

- [ ] My code follows pep8
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, or created a related issue.
- [ ] I have committed tests that prove my fix is effective or that my feature works. Or, I have opened an issue.
- [ ] I have added 2 reviewers to get the approval of.
