### PR TITLE
Allow filter by symbol in equipment comments

### DIFF
--- a/traiders/backend/api/filters/comment.py
+++ b/traiders/backend/api/filters/comment.py
@@ -1,4 +1,5 @@
 from django_filters import rest_framework as filters
+from django.forms import ValidationError
 
 from ..models import ArticleComment, EquipmentComment, Equipment
 
@@ -12,7 +13,14 @@ class ArticleCommentFilterSet(filters.FilterSet):
 
 
 class EquipmentCommentFilterSet(filters.FilterSet):
-    equipment = filters.ModelChoiceFilter(queryset=Equipment.objects.all())
+    equipment = filters.CharFilter(method='filter_by_equipment')
+
+    def filter_by_equipment(self, queryset, name, value):
+        # value can be either pk or symbol of an equipment
+        try:
+            return queryset.filter(equipment_id=int(value))
+        except ValueError:
+            return queryset.filter(equipment__symbol=value)
 
     class Meta:
         model = EquipmentComment

--- a/traiders/backend/api/test/test_equipmentcomments.py
+++ b/traiders/backend/api/test/test_equipmentcomments.py
@@ -128,8 +128,22 @@ class EquipmentCommentViewSetTests(APITestCase):
         # listing without equipment filter is not allowed
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_list_with_filter(self):
+    def test_list_with_id_filter(self):
         url = f"{reverse('equipmentcomment-list')}?equipment={self.equipment.pk}"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        comments = response.data
+        self.assertEqual(len(comments), 1)  # check the number of equipments returned
+
+        expected_fields = {'content', 'equipment', 'url', 'created_at', 'image', 'user', 'id',
+                           'is_liked', 'liked_by', 'num_likes'}
+
+        self.assertSetEqual(set(comments[0].keys()), expected_fields)
+
+    def test_list_with_symbol_filter(self):
+        url = f"{reverse('equipmentcomment-list')}?equipment={self.equipment.symbol}"
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Description

@rdilruba requested equipment comments to be filtered by symbols. 
PR allows comments to be filtered by both id and symbol of equipments through the same `equipment` field.


## Type of change
- [x] New feature (new functionality)

## How Has This Been Tested?
PR includes tests that filter id and symbol.

## Checklist:

- [x] My code follows pep8
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or created a related issue.
- [x] I have committed tests that prove my fix is effective or that my feature works. Or, I have opened an issue.
- [ ] I have added 2 reviewers to get the approval of.
