### PR TITLE
Fix order of parities in latest parity view

### DIFF
--- a/traiders/backend/api/models/parity_setting.py
+++ b/traiders/backend/api/models/parity_setting.py
@@ -18,5 +18,7 @@ class ParitySetting(models.Model):
     from_date = models.DateTimeField(blank=False)
     last_updated = models.DateTimeField(null=True, blank=True)  # null/blank means not updated yet
 
+    order = models.IntegerField(blank=False, default=0)
+
     def __str__(self):
         return "/".join([self.base_equipment.symbol, self.target_equipment.symbol])

--- a/traiders/backend/api/views/parity.py
+++ b/traiders/backend/api/views/parity.py
@@ -1,8 +1,9 @@
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.pagination import LimitOffsetPagination
+from django.db.models import When, Case
 
-from ..models import Parity, Equipment
+from ..models import Parity, Equipment, ParitySetting
 from ..serializers import ParitySerializer
 from ..filters import ParityFilterSet
 
@@ -22,7 +23,7 @@ class ParityLatestViewSet(ReadOnlyModelViewSet):
     pagination_class = LimitOffsetPagination
 
     def get_queryset(self):
-        parities = []
+        latest_parities = []
 
         distinct_id_pairs = Parity.objects.order_by().values_list('base_equipment', 'target_equipment').distinct()
 
@@ -30,6 +31,20 @@ class ParityLatestViewSet(ReadOnlyModelViewSet):
             parity = Parity.objects.order_by('-date').filter(base_equipment_id=base,
                                                              target_equipment_id=target).first()
 
-            parities.append(parity.id)
+            parity_setting = ParitySetting.objects.filter(base_equipment=parity.base_equipment,
+                                                          target_equipment=parity.target_equipment).first()
+            order = 0
+            if parity_setting:
+                order = parity_setting.order
 
-        return Parity.objects.filter(id__in=parities)
+            latest_parities.append((order, parity.base_equipment.symbol, parity.target_equipment.symbol, parity.id))
+
+        latest_parities.sort()
+        if latest_parities:
+            parity_ids = list(zip(*latest_parities))[-1]
+        else:
+            parity_ids = []
+
+        preserved_order = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(parity_ids)])
+
+        return Parity.objects.filter(id__in=parity_ids).order_by(preserved_order)


### PR DESCRIPTION
## Description

To fix the order of parities, `order` field of ParitySetting can be used. In the case of equal `order`s, alphabetic order is used.  

Fixes #378 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix

## How Has This Been Tested?
Tested by hand.

Test Issue # (issue)

## Checklist:

- [ ] My code follows pep8
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, or created a related issue.
- [ ] I have committed tests that prove my fix is effective or that my feature works. Or, I have opened an issue.
- [ ] I have added 2 reviewers to get the approval of.
